### PR TITLE
update to most current version of BTP TF provider

### DIFF
--- a/docu/4-expert/btp-terraform-setup/files/subscriber/provider.tf
+++ b/docu/4-expert/btp-terraform-setup/files/subscriber/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "0.2.0-beta2"
+      version = "0.4.0-beta1"
     }
   }
 }

--- a/docu/4-expert/saas-self-onboarding/files/terraform/provider.tf
+++ b/docu/4-expert/saas-self-onboarding/files/terraform/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "0.2.0-beta2"
+      version = "0.4.0-beta1"
     }
   }
   backend "pg" {}


### PR DESCRIPTION
This PR updates the Terraform provider for SAP BTP. During the beta phase this needs to happen with every new release.

Once the TF provider will be available for productive usage, this won't be necessary anymore.