### PR TITLE
Bug in service-manager.js prevents removal of Service Brokers or removes potentially a wrong service broker. 

### DIFF
--- a/code/srv/srv/utils/service-manager.js
+++ b/code/srv/srv/utils/service-manager.js
@@ -106,13 +106,15 @@ class ServiceManager {
     async getAllServiceBindings(tenant) {
         try {
             let token = await this.getToken();
-            let bindingQuery = new URLSearchParams({ label: `subaccount_id eq '${tenant}'` }).toString();
             let optionsBinding = {
                 method: 'GET',
-                url: this.credss.sm_url + `/v1/service_bindings?${bindingQuery}`,
+                url: this.credss.sm_url + `/v1/service_bindings`,
                 headers: {
                     'Content-Type': 'application/json',
                     Authorization: `Bearer ${token}`
+                },
+                params:{
+                    label:`subaccount_id eq '${tenant}'`
                 }
             }
             let response = await axios(optionsBinding);
@@ -198,14 +200,16 @@ class ServiceManager {
 
     async getServiceBroker(name){
         try {
-            let query = encodeURIComponent(`fieldQuery=name eq '${name}'`);
             let token = await this.getToken();
             let options = {
                 method: 'GET',
-                url: this.creds.sm_url + `/v1/service_brokers/?${query}`,
+                url: this.creds.sm_url + `/v1/service_brokers`,
                 headers: {
                     'Content-Type': 'application/json',
                     Authorization: `Bearer ${token}`
+                },
+                params: {
+                    fieldQuery:`name eq '${name}'`
                 }
             };
             let response = await axios(options);


### PR DESCRIPTION
We encountered this problem testing on a Subaccount where we subscribed this application in one subaccount from multiple provider instances (prod, dev, test). 

The current implementation pretends to work if you have only one service broker registered in the subscribing subaccount. The API call in `getServiceBroker` always returns all service brokers, because the filter condition is not applied. 
But only the first service broker from the result is returned here (https://github.com/SAP-samples/btp-cap-multitenant-saas/blob/222dcd0d334829011c59fdc3c55eee2604ed23d5/code/srv/srv/utils/service-manager.js#L214C16-L214C16)

As consequence `automation.js` possibly deletes the wrong service broker https://github.com/SAP-samples/btp-cap-multitenant-saas/blob/222dcd0d334829011c59fdc3c55eee2604ed23d5/code/srv/srv/utils/automator.js#L109

The problem originates in the URLEncoding of the search query. 

The final URL results in `https://service-manager.cfapps.eu10.hana.ondemand.com/v1/service_brokers?fieldQuery%3Dname%20eq%20%27*-api-sb-test******`

The problem is that the URL query's `=` sign is encoded to `%3D`; therefore, URL query parameters are not resolved. 
As a result, the query is not applied, and the API returns all three service broker instances.

![image](https://github.com/SAP-samples/btp-cap-multitenant-saas/assets/25772536/ea38e4cf-0a89-4a34-9344-5922c2d2f7ab)


With the fix in place, the result is as expected. 
![image](https://github.com/SAP-samples/btp-cap-multitenant-saas/assets/25772536/b073ed1f-6830-4b60-a89f-c237e4cd0a15)
