### PR TITLE
Network policy: Use standard label 

### DIFF
--- a/deploy/kyma/charts/sustainable-saas/charts/susaas-api/templates/network-policy.yaml
+++ b/deploy/kyma/charts/sustainable-saas/charts/susaas-api/templates/network-policy.yaml
@@ -15,4 +15,4 @@ spec:
             app: istio-ingressgateway
         namespaceSelector:
           matchLabels:
-            name: istio-system
+            kubernetes.io/metadata.name: istio-system

--- a/deploy/kyma/charts/sustainable-saas/charts/susaas-broker/templates/network-policy.yaml
+++ b/deploy/kyma/charts/sustainable-saas/charts/susaas-broker/templates/network-policy.yaml
@@ -15,4 +15,4 @@ spec:
               app: istio-ingressgateway
           namespaceSelector:
             matchLabels:
-              name: istio-system
+              kubernetes.io/metadata.name: istio-system

--- a/deploy/kyma/charts/sustainable-saas/charts/susaas-router/templates/network-policy.yaml
+++ b/deploy/kyma/charts/sustainable-saas/charts/susaas-router/templates/network-policy.yaml
@@ -22,4 +22,4 @@ spec:
             app.kubernetes.io/instance: ory
         namespaceSelector:
           matchLabels:
-            name: kyma-system
+            kubernetes.io/metadata.name

--- a/deploy/kyma/charts/sustainable-saas/charts/susaas-router/templates/network-policy.yaml
+++ b/deploy/kyma/charts/sustainable-saas/charts/susaas-router/templates/network-policy.yaml
@@ -15,7 +15,7 @@ spec:
             app: istio-ingressgateway
         namespaceSelector:
           matchLabels:
-            name: istio-system
+            kubernetes.io/metadata.name: istio-system
       - podSelector:
           matchLabels:
             app.kubernetes.io/name: oathkeeper

--- a/deploy/kyma/charts/sustainable-saas/charts/susaas-srv/templates/network-policy.yaml
+++ b/deploy/kyma/charts/sustainable-saas/charts/susaas-srv/templates/network-policy.yaml
@@ -22,4 +22,4 @@ spec:
               app: istio-ingressgateway
           namespaceSelector:
             matchLabels:
-              name: istio-system
+              kubernetes.io/metadata.name: istio-system


### PR DESCRIPTION
When going through this guide, I ran into an issue when subscribing. After debugging, it looks like it is due to the networkpolicy. This PR adjusts the chart to use the standard kubernetes namespace label in the network policy. 
For reference: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#automatic-labelling
It looks like this feature is available since August 4, 2021