### PR TITLE
Health endpoints

### DIFF
--- a/code/api/srv/server.js
+++ b/code/api/srv/server.js
@@ -2,7 +2,6 @@ import cds from '@sap/cds';
 import express from 'express';
 
 cds.on('bootstrap', async (app) => {
-    app.get('/healthz', (_, res) => { res.status(200).send('OK') })
     app.use(express.json({ limit: '50MB' }))
 });
 

--- a/code/srv/srv/server.js
+++ b/code/srv/srv/server.js
@@ -4,7 +4,6 @@ import ProvisioningService from './provisioning.js'
 import xsenv from '@sap/xsenv'
 
 cds.on('bootstrap', async (app) => {
-    app.get('/healthz', (_, res) => res.status(200).send('OK'));
     app.use(cov2ap());
 
     // Workaround to be removed for common db deployment on Kyma scenario.

--- a/deploy/cf/mta.yaml
+++ b/deploy/cf/mta.yaml
@@ -156,7 +156,7 @@ modules:
       disk-quota: 1024MB
       command: node ./node_modules/@sap/cds/bin/cds-serve
       health-check-type: http
-      health-check-http-endpoint: /healthz
+      health-check-http-endpoint: /health
       health-check-timeout: 180 # timeout at startup
       health-check-invocation-timeout: 180 # timeout for polling
     properties:

--- a/deploy/kyma/charts/sustainable-saas/charts/susaas-api/values.yaml
+++ b/deploy/kyma/charts/sustainable-saas/charts/susaas-api/values.yaml
@@ -31,9 +31,9 @@ hpa: # Horizontal Pod Autoscaler
 
 health_check:
   liveness:
-    path: /healthz
+    path: /health
   readiness:
-    path: /healthz
+    path: /health
 
 securityContext:
   user:

--- a/deploy/kyma/charts/sustainable-saas/charts/susaas-srv/values.yaml
+++ b/deploy/kyma/charts/sustainable-saas/charts/susaas-srv/values.yaml
@@ -44,9 +44,9 @@ hpa:
 
 health_check:
   liveness:
-    path: /healthz
+    path: /health
   readiness:
-    path: /healthz
+    path: /health
   
 securityContext:
   user:


### PR DESCRIPTION
CAP Framework already has a[ health endpoint](https://cap.cloud.sap/docs/guides/deployment/health-checks#health-checks) for health and readiness checks on the platforms, runtimes. 

This PR removes the custom developed /healtz endpoints developed by the project and uses the standard approach from CAP instead.